### PR TITLE
Node types: fix formatting and punctuation

### DIFF
--- a/downstream/modules/platform/proc-defining-node-types.adoc
+++ b/downstream/modules/platform/proc-defining-node-types.adoc
@@ -5,7 +5,7 @@
 = Defining {AutomationMesh} node types
 
 [role="_abstract"]
-You can a define node type either by its default value assigned by the inventory group or by using the `node_type` host variable. Specify the `node_type` either as part of the inventory group or within the inventory `vars` group.  This section provides examples of how you can define node types in your inventory file.  Nodes in `[execution_nodes]` default execution node_type. Hybrid node types can be overridden to be control type via `node_type=control`. Execution node type can be overridden to be hope node type via `node_type=hop`
+You can a define node type either by its default value assigned by the inventory group or by using the `node_type` host variable. Specify the `node_type` either as part of the inventory group or within the inventory `vars` group.  This section provides examples of how you can define node types in your inventory file.  Nodes in `[execution_nodes]` default execution node_type. Hybrid node types can be overridden to be control type via `node_type=control`. Execution node type can be overridden to be hope node type via `node_type=hop`.
 
 .Hybrid node
 
@@ -26,7 +26,8 @@ control-plane-1.example.com node_type=control
 -----
 
 .Execution node
-Nodes in the`[execution_nodes]` inventory group default to the *execution node* type. In the below example, we create a single execution node:
+
+Nodes in the `[execution_nodes]` inventory group default to the *execution node* type. In the below example, we create a single execution node:
 
 -----
 [execution_nodes]
@@ -34,6 +35,7 @@ execution-node-1.example.com
 -----
 
 .Hop node
+
 Convert execution nodes to hop nodes using `node_type=control`:
 
 -----
@@ -42,7 +44,8 @@ execution-node-1.example.com node_type=hop
 -----
 
 .Peer connections
-Create node-to-node connections using the `peers=` host variable. In the example below, we connect `control-plane-1.example.com` to `execution-node-1.example.com`, and `execution-node-1.example.com` to `execution-node-2.example.com `
+
+Create node-to-node connections using the `peers=` host variable. In the example below, we connect `control-plane-1.example.com` to `execution-node-1.example.com`, and `execution-node-1.example.com` to `execution-node-2.example.com`.
 
 -----
 [automationcontroller]


### PR DESCRIPTION
- Fixes spacing around `[execution_nodes]` and `execution-node-2.example.com` so that they are formatted correctly.
- Adds periods for consistent punctuation.
- Adds line breaks for markup consistency.